### PR TITLE
Fix two bugs in compensation-bot

### DIFF
--- a/reporting/compensation-bot/crParser.js
+++ b/reporting/compensation-bot/crParser.js
@@ -250,6 +250,10 @@
                     break;
                 }
             }
+            if (tableInfo.foundStart >= 0 && tableInfo.foundEnd < 0) {
+                // edge case: found the end of the markdown table at EOF (thanks @m52go)
+                tableInfo.foundEnd = lines.length;
+            }
             if (tableInfo.foundStart < 0 || tableInfo.foundEnd < 0) {
                 // error table not found
                 return false;

--- a/reporting/compensation-bot/index.js
+++ b/reporting/compensation-bot/index.js
@@ -70,6 +70,12 @@ module.exports = app => {
         app.log("safeMode: " + safeMode);
         app.log("================ ISSUE # " + context.payload.issue.number + " =====================");
 
+        var isRATE = /^BSQ rate for cycle/gi.test(context.payload.issue.title);
+        if (isRATE) {
+            app.log("issue is BSQ rate sticky, therefore not parsing as a comp request");
+            return false;
+        }
+
         // parse and log the CR so we can see in the logs what's going on
         crParser.parseContributionRequest(context.payload.issue.body);
         app.log(crParser.writeLinterSummary());


### PR DESCRIPTION
- Fixes BSQ rate announcement interpreted as a compensation request
- Fixes does not pick up table when its last line has no EOL marker